### PR TITLE
Fix sidebar collapsing

### DIFF
--- a/planalesson.html
+++ b/planalesson.html
@@ -307,15 +307,12 @@ $("input:checkbox").on('click', function() {
 	</script>
 
 	<script>
-    var expanded = false;
     function showCheckboxes(name) {
         var checkboxes = document.getElementById(name);
-        if (!expanded) {
-            checkboxes.style.display = "block";
-            expanded = true;
-        } else {
+		if (checkboxes.style.display !== "none") {
             checkboxes.style.display = "none";
-            expanded = false;
+        } else {
+            checkboxes.style.display = "block";
         }
     }
 	</script>


### PR DESCRIPTION
By having a single variable (i.e. `expanded`), you're stuck with all of the menus relying on the same status so they'll probably alternate. Meaning when one menu is collapsed or opened, then the other menus would have the same value as the first menu even if they are already open/closed. Instead you can just check the style you're looking for directly and modify it to be the opposite as shown in this pull request.

Basically, if the display of the checkboxes is not none (it's visible), then hide it; otherwise, display it.
